### PR TITLE
changes required to upgrade to Crux 1.17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Clojure
 .cpcache
+.nrepl-port
 
 # Gradle
 .gradle/

--- a/crux-corda/build.gradle.kts
+++ b/crux-corda/build.gradle.kts
@@ -17,7 +17,7 @@ cordapp {
 
 dependencies {
     implementation("org.clojure", "clojure", "1.10.0")
-    implementation("juxt", "crux-core", "20.09-1.12.1-beta")
+    implementation("juxt", "crux-core", "21.06-1.17.1-beta")
     implementation("seancorfield", "next.jdbc", "1.1.588")
     implementation(project(":crux-corda-state"))
 

--- a/iou-workflow/build.gradle.kts
+++ b/iou-workflow/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     cordapp(project(":iou-contract"))
     cordapp(project(":crux-corda-state"))
     cordapp(project(":crux-corda"))
-    implementation("juxt", "crux-core", "20.09-1.12.1-beta")
+    implementation("juxt", "crux-core", "21.06-1.17.1-beta")
 
     testImplementation("junit", "junit", "4.12")
     testImplementation(cordaGroup, "corda-node-driver", cordaVersion)

--- a/iou-workflow/src/test/kotlin/com/example/workflow/IOUFlowTests.kt
+++ b/iou-workflow/src/test/kotlin/com/example/workflow/IOUFlowTests.kt
@@ -1,6 +1,5 @@
 package com.example.workflow
 
-import clojure.lang.Keyword
 import com.example.contract.IOUState
 import com.example.service.CruxService
 import net.corda.core.node.services.queryBy
@@ -66,15 +65,13 @@ class IOUFlowTests {
             }
         }
 
-        val txIdKey = Keyword.intern("crux.tx/tx-id")
-
         // We check Crux gets a transaction
         for (node in nodes) {
             val cruxService = node.services.cordaService(CruxService::class.java)
             val cruxNode = cruxService.node
 
-            assertEquals(1L, cruxService.cruxTx(signedTx.id)!![txIdKey])
-            assertEquals(1L, cruxNode.latestCompletedTx()[txIdKey])
+            assertEquals(1L, cruxService.cruxTx(signedTx.id)!!.id)
+            assertEquals(1L, cruxNode.latestCompletedTx().id)
 
             assertEquals(
                 listOf(a.info.singleIdentity().name.toString(), b.info.singleIdentity().name.toString(), 1L),


### PR DESCRIPTION
Implementation notes:

* The Crux Java API went through a large upgrade somewhere in 1.14-1.17 (I forget which one). 
  * I've taken a reasonably naive approach to just change `NodeConfigurator` to `NodeConfiguration.Builder` (they're pretty much the same class), but the idea behind that upstream change was to expose `NodeConfiguration` as a data structure rather than a closure - it might be preferable to use that, although it doesn't currently allow you to build on an existing config object.
  * Various places in the Java API now return a strongly-typed `TransactionInstant` object rather than `Map<Keyword, ?>` from submitting transactions, latest-completed-tx, etc - I've extended this to the `crux-corda` methods that return transactions. Impact is visible in the `IOUFlowTests` - i.e. rather than looking up the tx-id by Clojure keyword, we use the `getId` method (or just the `id` field, as it manifests itself in Kotlin).